### PR TITLE
[JENKINS-44074] Add an integration test and the maven-failsafe-plugin…

### DIFF
--- a/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
+++ b/jenkins-plugin/src/test/java/org/jenkinsci/plugins/pipeline/maven/WithMavenStepOnMasterTest.java
@@ -145,7 +145,7 @@ public class WithMavenStepOnMasterTest {
         String pipelineScript = "node('master') {\n" +
                 "    git($/" + gitRepoRule.toString() + "/$)\n" +
                 "    withMaven() {\n" +
-                "        sh 'mvn package'\n" +
+                "        sh 'mvn package verify'\n" +
                 "    }\n" +
                 "}";
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_jar_project/pom.xml
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_jar_project/pom.xml
@@ -12,5 +12,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.20</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>
 

--- a/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_jar_project/src/test/java/com/example/MonoModuleMavenAppIT.java
+++ b/jenkins-plugin/src/test/resources/org/jenkinsci/plugins/pipeline/maven/test/test_maven_projects/maven_jar_project/src/test/java/com/example/MonoModuleMavenAppIT.java
@@ -1,0 +1,14 @@
+package com.example;
+
+import org.junit.Test;
+
+/**
+ * Integration test for the maven-failsafe-plugin
+ */
+public class MonoModuleMavenAppIT {
+
+    @Test
+    public void success(){
+        System.out.println("MonoModuleMavenAppIT#success");
+    }
+}


### PR DESCRIPTION
[JENKINS-44074](https://issues.jenkins-ci.org/browse/JENKINS-44074) Add an integration test and the maven-failsafe-plugin in the test “maven jar project”

See generated maven-event-spy logs and mvn build logs at https://gist.github.com/cyrille-leclerc/bc2720d141928d1f69590fb27c9a1a6c